### PR TITLE
Colorpatch

### DIFF
--- a/src/tw-recolor/build.js
+++ b/src/tw-recolor/build.js
@@ -1,0 +1,18 @@
+/* eslint-disable import/no-commonjs */
+
+const OLD_PRIMARY_COLOR = '#855cd6';
+
+const loader = source => `
+    const original = ${JSON.stringify(source)};
+
+    const getSRC = () => {
+        const recolored = typeof Recolor === 'object' ? (
+            original.replace(/${OLD_PRIMARY_COLOR}/gi, Recolor.primary)
+        ) : original;
+        return 'data:image/svg+xml;,' + encodeURIComponent(recolored);
+    };
+
+    export default getSRC;
+`;
+
+module.exports = loader;

--- a/src/tw-recolor/render.jsx
+++ b/src/tw-recolor/render.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
+
+// This is a wrapper around <img> that forces re-render when theme state updates.
+
+const TWRenderRecoloredImage = ({
+    src,
+    ...props
+}) => (
+    <img
+        src={typeof src === 'function' ? src() : src}
+        {...props}
+    />
+);
+
+TWRenderRecoloredImage.propTypes = {
+    src: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
+};
+
+const mapStateToProps = state => ({
+    theme: state.scratchGui ? state.scratchGui.theme.theme : ''
+});
+
+const mapDispatchToProps = () => ({});
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(TWRenderRecoloredImage);


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (please include link)?_
https://github.com/OmniBlocks/scratch-gui/issues/93
### Proposed Changes

_Describe what this Pull Request does_

allows for theme changing because it was hardcoded to blue

### Reason for Changes

_Explain why these changes should be made_
its sucks that it's hardcoded to blue and it was a mistake from the begining
### Test Coverage

_Please show how you have added tests to cover your changes_
uhh... test?? what's a test... ha...ha...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic theme-based recoloring for SVG images, replacing the old primary color with the current theme color for consistent visuals.
  * Images are served as data URLs and refresh automatically when the theme changes, ensuring instant updates across the UI.
  * New image component accepts either a direct URL or a function to generate one, offering flexible sourcing.
  * Works out of the box—no user configuration required—improving appearance and responsiveness in themed environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->